### PR TITLE
feat: add structured logging and observability hooks

### DIFF
--- a/internal/bridge.go
+++ b/internal/bridge.go
@@ -48,29 +48,3 @@ func messageToMap(msg *service.Message) (map[string]any, error) {
 	return result, nil
 }
 
-// mapToMessage converts a map to a Bento service.Message.
-// If the map has a "body" key, its JSON representation becomes the message bytes.
-// Additional metadata keys are attached.
-func mapToMessage(data map[string]any) *service.Message {
-	var body []byte
-
-	if b, ok := data["body"]; ok {
-		if s, ok2 := b.(string); ok2 {
-			body = []byte(s)
-		} else {
-			body, _ = json.Marshal(b)
-		}
-	} else {
-		body, _ = json.Marshal(data)
-	}
-
-	msg := service.NewMessage(body)
-
-	if meta, ok := data["metadata"].(map[string]any); ok {
-		for k, v := range meta {
-			msg.MetaSetMut(k, v)
-		}
-	}
-
-	return msg
-}

--- a/internal/bridge.go
+++ b/internal/bridge.go
@@ -17,7 +17,33 @@ func configToYAML(config map[string]any) (string, error) {
 	return string(data), nil
 }
 
-// messageToMap converts a Bento service.Message to a plain map.
+// mapToMessage converts a map to a Bento service.Message.
+// If the map has a "body" key, its JSON representation becomes the message bytes.
+// Additional metadata keys are attached.
+func mapToMessage(data map[string]any) *service.Message {
+	var body []byte
+
+	if b, ok := data["body"]; ok {
+		if s, ok2 := b.(string); ok2 {
+			body = []byte(s)
+		} else {
+			body, _ = json.Marshal(b)
+		}
+	} else {
+		body, _ = json.Marshal(data)
+	}
+
+	msg := service.NewMessage(body)
+
+	if meta, ok := data["metadata"].(map[string]any); ok {
+		for k, v := range meta {
+			msg.MetaSetMut(k, v)
+		}
+	}
+
+	return msg
+}
+
 // The message body is decoded as JSON if possible; otherwise stored as a raw string.
 func messageToMap(msg *service.Message) (map[string]any, error) {
 	raw, err := msg.AsBytes()

--- a/internal/bridge.go
+++ b/internal/bridge.go
@@ -20,17 +20,26 @@ func configToYAML(config map[string]any) (string, error) {
 // mapToMessage converts a map to a Bento service.Message.
 // If the map has a "body" key, its JSON representation becomes the message bytes.
 // Additional metadata keys are attached.
-func mapToMessage(data map[string]any) *service.Message {
+// An error is returned if JSON marshalling of the body fails.
+func mapToMessage(data map[string]any) (*service.Message, error) {
 	var body []byte
 
 	if b, ok := data["body"]; ok {
 		if s, ok2 := b.(string); ok2 {
 			body = []byte(s)
 		} else {
-			body, _ = json.Marshal(b)
+			var err error
+			body, err = json.Marshal(b)
+			if err != nil {
+				return nil, fmt.Errorf("marshal message body: %w", err)
+			}
 		}
 	} else {
-		body, _ = json.Marshal(data)
+		var err error
+		body, err = json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("marshal message data: %w", err)
+		}
 	}
 
 	msg := service.NewMessage(body)
@@ -41,7 +50,7 @@ func mapToMessage(data map[string]any) *service.Message {
 		}
 	}
 
-	return msg
+	return msg, nil
 }
 
 // The message body is decoded as JSON if possible; otherwise stored as a raw string.

--- a/internal/bridge.go
+++ b/internal/bridge.go
@@ -47,4 +47,3 @@ func messageToMap(msg *service.Message) (map[string]any, error) {
 
 	return result, nil
 }
-

--- a/internal/bridge_test.go
+++ b/internal/bridge_test.go
@@ -128,7 +128,10 @@ func TestMapToMessage_WithBody(t *testing.T) {
 		"body": "hello world",
 	}
 
-	msg := mapToMessage(data)
+	msg, err := mapToMessage(data)
+	if err != nil {
+		t.Fatalf("mapToMessage() returned error: %v", err)
+	}
 	if msg == nil {
 		t.Fatal("mapToMessage() returned nil")
 	}
@@ -147,7 +150,10 @@ func TestMapToMessage_WithJSONBody(t *testing.T) {
 		"body": map[string]any{"key": "value"},
 	}
 
-	msg := mapToMessage(data)
+	msg, err := mapToMessage(data)
+	if err != nil {
+		t.Fatalf("mapToMessage() returned error: %v", err)
+	}
 	if msg == nil {
 		t.Fatal("mapToMessage() returned nil")
 	}
@@ -166,7 +172,10 @@ func TestMapToMessage_WithoutBody_MarshalsFull(t *testing.T) {
 		"key": "value",
 	}
 
-	msg := mapToMessage(data)
+	msg, err := mapToMessage(data)
+	if err != nil {
+		t.Fatalf("mapToMessage() returned error: %v", err)
+	}
 	if msg == nil {
 		t.Fatal("mapToMessage() returned nil")
 	}
@@ -188,7 +197,10 @@ func TestMapToMessage_WithMetadata(t *testing.T) {
 		},
 	}
 
-	msg := mapToMessage(data)
+	msg, err := mapToMessage(data)
+	if err != nil {
+		t.Fatalf("mapToMessage() returned error: %v", err)
+	}
 	if msg == nil {
 		t.Fatal("mapToMessage() returned nil")
 	}
@@ -203,7 +215,10 @@ func TestMapToMessage_WithMetadata(t *testing.T) {
 }
 
 func TestMapToMessage_EmptyMap(t *testing.T) {
-	msg := mapToMessage(map[string]any{})
+	msg, err := mapToMessage(map[string]any{})
+	if err != nil {
+		t.Fatalf("mapToMessage() with empty map returned error: %v", err)
+	}
 	if msg == nil {
 		t.Fatal("mapToMessage() with empty map returned nil")
 	}
@@ -220,7 +235,10 @@ func TestRoundTrip_MessageToMapToMessage(t *testing.T) {
 	}
 
 	// Convert back to message.
-	reconstructed := mapToMessage(m)
+	reconstructed, err := mapToMessage(m)
+	if err != nil {
+		t.Fatalf("mapToMessage() returned error: %v", err)
+	}
 	if reconstructed == nil {
 		t.Fatal("mapToMessage() returned nil")
 	}

--- a/internal/broker_module.go
+++ b/internal/broker_module.go
@@ -21,6 +21,9 @@ type brokerModule struct {
 	subscriber      sdk.MessageSubscriber
 	streams         map[string]*service.Stream
 	mu              sync.RWMutex
+	log             *bentoLogger
+	metrics         *StreamMetrics
+	health          *healthTracker
 }
 
 // SetMessagePublisher satisfies the MessageAwareModule interface.
@@ -34,10 +37,14 @@ func (m *brokerModule) SetMessageSubscriber(sub sdk.MessageSubscriber) {
 }
 
 func newBrokerModule(name string, config map[string]any) (*brokerModule, error) {
+	metrics := newStreamMetrics()
 	return &brokerModule{
 		name:    name,
 		config:  config,
 		streams: make(map[string]*service.Stream),
+		log:     newLogger("bento.broker", name),
+		metrics: metrics,
+		health:  newHealthTracker(metrics),
 	}, nil
 }
 
@@ -60,6 +67,8 @@ func (m *brokerModule) Init() error {
 
 // Start is a no-op; individual per-topic streams are created on demand.
 func (m *brokerModule) Start(_ context.Context) error {
+	m.health.SetRunning(true)
+	m.log.LogStreamStart(m.transport)
 	return nil
 }
 
@@ -72,23 +81,30 @@ func (m *brokerModule) Stop(ctx context.Context) error {
 
 	var firstErr error
 	for topic, stream := range m.streams {
-		if err := stream.Stop(ctx); err != nil {
-			slog.Error("failed to stop broker stream", "error", err, "module", m.name, "topic", topic)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("bento.broker %q: stop stream for topic %q: %w", m.name, topic, err)
-			}
-			continue
+		if err := stream.Stop(ctx); err != nil && firstErr == nil {
+			m.metrics.RecordError()
+			m.log.LogStreamError(err, slog.String("topic", topic))
+			firstErr = fmt.Errorf("bento.broker %q: stop stream for topic %q: %w", m.name, topic, err)
 		}
 		slog.Info("broker stream stopped", "module", m.name, "topic", topic)
 	}
 	m.streams = make(map[string]*service.Stream)
+
+	m.health.SetRunning(false)
+	snap := m.metrics.Snapshot()
+	m.log.LogStreamStop(snap.MessagesIn+snap.MessagesOut,
+		slog.String("transport", m.transport),
+		slog.Duration("uptime", snap.Uptime),
+		slog.Int64("errors", snap.Errors),
+	)
+
 	return firstErr
 }
 
 // ensureStream returns (creating if necessary) a running stream for topic.
 // This is used internally when the broker needs a dedicated in-process pipe.
 //
-//nolint:unused // Reserved for future on-demand topic routing implementation.
+//nolint:unused // Reserved for future use by broker consumers.
 func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service.Stream, error) {
 	m.mu.RLock()
 	if s, ok := m.streams[topic]; ok {
@@ -123,13 +139,15 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 	}
 
 	pub := m.publisher
-	moduleName := m.name
+	metrics := m.metrics
+	log := m.log
 
 	if pub != nil {
 		if err := builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
 			payload, msgErr := msg.AsBytes()
 			if msgErr != nil {
-				slog.Error("failed to read broker message", "error", msgErr, "module", moduleName, "topic", topic)
+				metrics.RecordError()
+				log.LogStreamError(msgErr, slog.String("topic", topic))
 				return msgErr
 			}
 			meta := map[string]string{}
@@ -142,9 +160,13 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 
 			_, pubErr := pub.Publish(topic, payload, meta)
 			if pubErr != nil {
-				slog.Error("failed to publish from broker", "error", pubErr, "module", moduleName, "topic", topic)
+				metrics.RecordError()
+				log.LogStreamError(pubErr, slog.String("phase", "publish"), slog.String("topic", topic))
+				return pubErr
 			}
-			return pubErr
+			metrics.RecordMessageOut()
+			log.LogMessageProcessed(topic)
+			return nil
 		}); err != nil {
 			return nil, fmt.Errorf("add consumer for topic %q: %w", topic, err)
 		}
@@ -155,13 +177,23 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 		return nil, fmt.Errorf("build stream for topic %q: %w", topic, err)
 	}
 
+	m.log.LogTopicEvent("stream_created", topic,
+		slog.String("transport", m.transport),
+	)
+
 	go func() {
-		if err := stream.Run(ctx); err != nil && ctx.Err() == nil {
-			slog.Error("broker stream failed", "error", err, "module", moduleName, "topic", topic)
+		if runErr := stream.Run(ctx); runErr != nil && ctx.Err() == nil {
+			metrics.RecordError()
+			log.LogStreamError(runErr, slog.String("topic", topic))
 		}
 	}()
 
 	m.streams[topic] = stream
 	slog.Info("broker stream created", "module", m.name, "topic", topic)
 	return stream, nil
+}
+
+// Health returns the current health report for this broker module.
+func (m *brokerModule) Health() HealthReport {
+	return m.health.Report()
 }

--- a/internal/broker_module.go
+++ b/internal/broker_module.go
@@ -75,18 +75,25 @@ func (m *brokerModule) Start(_ context.Context) error {
 
 // Stop shuts down all managed streams.
 func (m *brokerModule) Stop(ctx context.Context) error {
+	// Copy the streams map under the lock, then release it before calling
+	// stream.Stop to avoid holding the lock during potentially blocking I/O
+	// (deadlock risk if a stream goroutine also acquires the lock).
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	toStop := make(map[string]*service.Stream, len(m.streams))
+	for topic, s := range m.streams {
+		toStop[topic] = s
+	}
+	m.streams = make(map[string]*service.Stream)
+	m.mu.Unlock()
 
 	var firstErr error
-	for topic, stream := range m.streams {
+	for topic, stream := range toStop {
 		if err := stream.Stop(ctx); err != nil && firstErr == nil {
 			m.metrics.RecordError()
 			m.log.LogStreamError(err, slog.String("topic", topic))
 			firstErr = fmt.Errorf("bento.broker %q: stop stream for topic %q: %w", m.name, topic, err)
 		}
 	}
-	m.streams = make(map[string]*service.Stream)
 
 	m.health.SetRunning(false)
 	m.metrics.MarkStopped()

--- a/internal/broker_module.go
+++ b/internal/broker_module.go
@@ -78,8 +78,6 @@ func (m *brokerModule) Stop(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	slog.Info("stopping bento broker", "module", m.name, "topics", len(m.streams))
-
 	var firstErr error
 	for topic, stream := range m.streams {
 		if err := stream.Stop(ctx); err != nil && firstErr == nil {
@@ -87,7 +85,6 @@ func (m *brokerModule) Stop(ctx context.Context) error {
 			m.log.LogStreamError(err, slog.String("topic", topic))
 			firstErr = fmt.Errorf("bento.broker %q: stop stream for topic %q: %w", m.name, topic, err)
 		}
-		slog.Info("broker stream stopped", "module", m.name, "topic", topic)
 	}
 	m.streams = make(map[string]*service.Stream)
 
@@ -123,8 +120,6 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 		return s, nil
 	}
 
-	slog.Info("creating broker stream", "module", m.name, "topic", topic, "transport", m.transport)
-
 	// Build a simple in-memory stream that holds messages for this topic.
 	// The actual transport is configured via transportConfig / transport.
 	builder := service.NewStreamBuilder()
@@ -157,9 +152,6 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 				meta[k] = fmt.Sprintf("%v", v)
 				return nil
 			})
-
-			slog.Debug("broker forwarding message", "module", moduleName, "topic", topic, "size", len(payload))
-
 			_, pubErr := pub.Publish(topic, payload, meta)
 			if pubErr != nil {
 				metrics.RecordError()
@@ -201,7 +193,6 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 	}()
 
 	m.streams[topic] = stream
-	slog.Info("broker stream created", "module", m.name, "topic", topic)
 	return stream, nil
 }
 

--- a/internal/broker_module.go
+++ b/internal/broker_module.go
@@ -68,6 +68,7 @@ func (m *brokerModule) Init() error {
 // Start is a no-op; individual per-topic streams are created on demand.
 func (m *brokerModule) Start(_ context.Context) error {
 	m.health.SetRunning(true)
+	m.metrics.MarkStarted()
 	m.log.LogStreamStart(m.transport)
 	return nil
 }
@@ -91,6 +92,7 @@ func (m *brokerModule) Stop(ctx context.Context) error {
 	m.streams = make(map[string]*service.Stream)
 
 	m.health.SetRunning(false)
+	m.metrics.MarkStopped()
 	snap := m.metrics.Snapshot()
 	m.log.LogStreamStop(snap.MessagesIn+snap.MessagesOut,
 		slog.String("transport", m.transport),
@@ -182,9 +184,19 @@ func (m *brokerModule) ensureStream(ctx context.Context, topic string) (*service
 	)
 
 	go func() {
-		if runErr := stream.Run(ctx); runErr != nil && ctx.Err() == nil {
-			metrics.RecordError()
-			log.LogStreamError(runErr, slog.String("topic", topic))
+		if runErr := stream.Run(ctx); ctx.Err() == nil {
+			// Stream exited without context cancellation; remove it from the
+			// active streams map so it can be recreated on next access.
+			m.mu.Lock()
+			delete(m.streams, topic)
+			m.mu.Unlock()
+			if runErr != nil {
+				metrics.RecordError()
+				log.LogStreamError(runErr, slog.String("topic", topic))
+			}
+			log.LogTopicEvent("stream_stopped", topic,
+				slog.String("reason", "run_exited"),
+			)
 		}
 	}()
 

--- a/internal/broker_module_test.go
+++ b/internal/broker_module_test.go
@@ -126,6 +126,46 @@ func TestBrokerModule_StartStop(t *testing.T) {
 	}
 }
 
+func TestBrokerModule_Health(t *testing.T) {
+	m, _ := newBrokerModule("test-broker", map[string]any{
+		"transport": "memory",
+	})
+
+	// Before start: unhealthy
+	report := m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy before start, got %s", report.StatusText)
+	}
+
+	if err := m.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// After start: healthy
+	report = m.Health()
+	if report.Status != HealthStatusHealthy {
+		t.Errorf("expected healthy after start, got %s", report.StatusText)
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// After stop: unhealthy
+	report = m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy after stop, got %s", report.StatusText)
+	}
+}
+
 func TestBrokerModule_EnsureStream(t *testing.T) {
 	// Use generate transport so ensureStream can build a valid Bento stream.
 	// count=0 means infinite generation; the stream will be stopped at the end.

--- a/internal/broker_module_test.go
+++ b/internal/broker_module_test.go
@@ -226,8 +226,29 @@ func TestBrokerModule_EnsureStream(t *testing.T) {
 		t.Errorf("expected 2 streams, got %d", streamCount)
 	}
 
-	// Allow goroutines to start running streams
-	time.Sleep(50 * time.Millisecond)
+	// Poll until both stream goroutines have called stream.Run, which is
+	// indicated by the stream being able to accept a Stop without returning
+	// "has not been run yet". We verify by polling the stream count: once the
+	// goroutines are running, Stop will succeed.  Use a short yield loop instead
+	// of a fixed sleep.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m.mu.RLock()
+		count := len(m.streams)
+		m.mu.RUnlock()
+		if count == 2 {
+			// Streams are registered; give goroutines a chance to call Run.
+			// Yield to the scheduler repeatedly rather than sleeping.
+			for range 5 {
+				time.Sleep(10 * time.Millisecond)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("streams did not start within timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// Stop should clean up all streams
 	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/health.go
+++ b/internal/health.go
@@ -1,0 +1,99 @@
+package internal
+
+import (
+	"sync"
+	"time"
+)
+
+// HealthStatus represents the health state of a stream or module.
+type HealthStatus int
+
+const (
+	// HealthStatusHealthy means the stream is operating normally.
+	HealthStatusHealthy HealthStatus = iota
+	// HealthStatusDegraded means the stream has experienced some errors but is
+	// still running.
+	HealthStatusDegraded
+	// HealthStatusUnhealthy means the stream has stopped or is not functioning.
+	HealthStatusUnhealthy
+)
+
+// String returns a human-readable representation of HealthStatus.
+func (s HealthStatus) String() string {
+	switch s {
+	case HealthStatusHealthy:
+		return "healthy"
+	case HealthStatusDegraded:
+		return "degraded"
+	default:
+		return "unhealthy"
+	}
+}
+
+// HealthReport is a point-in-time summary of a stream's health.
+type HealthReport struct {
+	Status          HealthStatus  `json:"status"`
+	StatusText      string        `json:"status_text"`
+	MessagesIn      int64         `json:"messages_in"`
+	MessagesOut     int64         `json:"messages_out"`
+	Errors          int64         `json:"errors"`
+	Uptime          time.Duration `json:"uptime_ns"`
+	LastMessageTime time.Time     `json:"last_message_time"`
+}
+
+// healthTracker derives health status from a StreamMetrics instance and
+// additional runtime flags set by lifecycle methods.
+type healthTracker struct {
+	metrics *StreamMetrics
+
+	mu      sync.Mutex
+	running bool
+
+	// errorThreshold is the number of errors after which status transitions
+	// to degraded; defaults to 1.
+	errorThreshold int64
+}
+
+// newHealthTracker creates a healthTracker backed by the given metrics.
+func newHealthTracker(m *StreamMetrics) *healthTracker {
+	return &healthTracker{
+		metrics:        m,
+		errorThreshold: 1,
+	}
+}
+
+// SetRunning marks the stream as started (true) or stopped (false).
+func (h *healthTracker) SetRunning(running bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.running = running
+}
+
+// Report returns the current HealthReport by examining metrics and state.
+func (h *healthTracker) Report() HealthReport {
+	h.mu.Lock()
+	running := h.running
+	h.mu.Unlock()
+
+	snap := h.metrics.Snapshot()
+
+	var status HealthStatus
+	switch {
+	case !running:
+		status = HealthStatusUnhealthy
+	case snap.Errors >= h.errorThreshold:
+		status = HealthStatusDegraded
+	default:
+		status = HealthStatusHealthy
+	}
+
+	return HealthReport{
+		Status:          status,
+		StatusText:      status.String(),
+		MessagesIn:      snap.MessagesIn,
+		MessagesOut:     snap.MessagesOut,
+		Errors:          snap.Errors,
+		Uptime:          snap.Uptime,
+		LastMessageTime: snap.LastMessageTime,
+	}
+}

--- a/internal/input_module.go
+++ b/internal/input_module.go
@@ -65,6 +65,16 @@ func (m *inputModule) Init() error {
 	return nil
 }
 
+// inputTransportType extracts the top-level key from the input config map,
+// which represents the actual Bento input type (e.g. "kafka", "generate").
+// Falls back to "bento.input" if the type cannot be determined.
+func inputTransportType(inputCfg map[string]any) string {
+	for k := range inputCfg {
+		return k
+	}
+	return "bento.input"
+}
+
 // Start builds and runs the Bento input stream. Each message received is
 // published to the host EventBus topic.
 func (m *inputModule) Start(ctx context.Context) error {
@@ -136,7 +146,10 @@ func (m *inputModule) Start(ctx context.Context) error {
 	m.cancel = cancel
 
 	m.metrics.MarkStarted()
-	m.log.LogStreamStart("bento.input",
+	// Extract the actual input transport type (e.g. "kafka", "generate") for
+	// more informative log output instead of the generic module type string.
+	transport := inputTransportType(inputCfg)
+	m.log.LogStreamStart(transport,
 		slog.String("target_topic", m.targetTopic),
 		slog.String("target_broker", m.targetBroker),
 	)

--- a/internal/input_module.go
+++ b/internal/input_module.go
@@ -20,6 +20,9 @@ type inputModule struct {
 	stream       *service.Stream
 	cancel       context.CancelFunc
 	done         chan struct{}
+	log          *bentoLogger
+	metrics      *StreamMetrics
+	health       *healthTracker
 }
 
 // SetMessagePublisher satisfies the MessageAwareModule interface.
@@ -32,10 +35,14 @@ func (m *inputModule) SetMessagePublisher(pub sdk.MessagePublisher) {
 func (m *inputModule) SetMessageSubscriber(_ sdk.MessageSubscriber) {}
 
 func newInputModule(name string, config map[string]any) (*inputModule, error) {
+	metrics := newStreamMetrics()
 	return &inputModule{
-		name:   name,
-		config: config,
-		done:   make(chan struct{}),
+		name:    name,
+		config:  config,
+		done:    make(chan struct{}),
+		log:     newLogger("bento.input", name),
+		metrics: metrics,
+		health:  newHealthTracker(metrics),
 	}, nil
 }
 
@@ -85,12 +92,14 @@ func (m *inputModule) Start(ctx context.Context) error {
 
 	topic := m.targetTopic
 	pub := m.publisher
-	moduleName := m.name
+	metrics := m.metrics
+	log := m.log
 
 	if err := builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
 		payload, msgErr := msg.AsBytes()
 		if msgErr != nil {
-			slog.Error("failed to read message bytes", "error", msgErr, "module", moduleName)
+			metrics.RecordError()
+			log.LogStreamError(msgErr, slog.String("phase", "read_bytes"))
 			return fmt.Errorf("read message bytes: %w", msgErr)
 		}
 
@@ -109,9 +118,14 @@ func (m *inputModule) Start(ctx context.Context) error {
 
 		_, pubErr := pub.Publish(topic, payload, meta)
 		if pubErr != nil {
-			slog.Error("failed to publish message", "error", pubErr, "module", moduleName, "topic", topic)
+			metrics.RecordError()
+			log.LogStreamError(pubErr, slog.String("phase", "publish"))
+			return pubErr
 		}
-		return pubErr
+
+		metrics.RecordMessageOut()
+		log.LogMessageProcessed(topic)
+		return nil
 	}); err != nil {
 		return fmt.Errorf("bento.input %q: add consumer func: %w", m.name, err)
 	}
@@ -125,12 +139,17 @@ func (m *inputModule) Start(ctx context.Context) error {
 	runCtx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
-	slog.Info("bento input running", "module", m.name)
+	m.health.SetRunning(true)
+	m.log.LogStreamStart("bento.input",
+		slog.String("target_topic", m.targetTopic),
+		slog.String("target_broker", m.targetBroker),
+	)
 
 	go func() {
 		defer close(m.done)
-		if err := stream.Run(runCtx); err != nil && runCtx.Err() == nil {
-			slog.Error("bento input stream failed", "error", err, "module", moduleName)
+		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
+			m.metrics.RecordError()
+			m.log.LogStreamError(runErr)
 		}
 	}()
 
@@ -143,7 +162,8 @@ func (m *inputModule) Stop(ctx context.Context) error {
 
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
-			slog.Error("error stopping bento input", "error", err, "module", m.name)
+			m.metrics.RecordError()
+			m.log.LogStreamError(err, slog.String("phase", "stop"))
 			return fmt.Errorf("bento.input %q: stop: %w", m.name, err)
 		}
 	}
@@ -156,5 +176,19 @@ func (m *inputModule) Stop(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
+	m.health.SetRunning(false)
+	snap := m.metrics.Snapshot()
+	m.log.LogStreamStop(snap.MessagesOut,
+		slog.String("target_topic", m.targetTopic),
+		slog.Duration("uptime", snap.Uptime),
+		slog.Int64("errors", snap.Errors),
+	)
+
 	return nil
+}
+
+// Health returns the current health report for this input module.
+func (m *inputModule) Health() HealthReport {
+	return m.health.Report()
 }

--- a/internal/input_module.go
+++ b/internal/input_module.go
@@ -140,6 +140,7 @@ func (m *inputModule) Start(ctx context.Context) error {
 	m.cancel = cancel
 
 	m.health.SetRunning(true)
+	m.metrics.MarkStarted()
 	m.log.LogStreamStart("bento.input",
 		slog.String("target_topic", m.targetTopic),
 		slog.String("target_broker", m.targetBroker),
@@ -147,9 +148,12 @@ func (m *inputModule) Start(ctx context.Context) error {
 
 	go func() {
 		defer close(m.done)
-		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
-			m.metrics.RecordError()
-			m.log.LogStreamError(runErr)
+		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
+			m.health.SetRunning(false)
+			if runErr != nil {
+				m.metrics.RecordError()
+				m.log.LogStreamError(runErr)
+			}
 		}
 	}()
 
@@ -178,6 +182,7 @@ func (m *inputModule) Stop(ctx context.Context) error {
 	}
 
 	m.health.SetRunning(false)
+	m.metrics.MarkStopped()
 	snap := m.metrics.Snapshot()
 	m.log.LogStreamStop(snap.MessagesOut,
 		slog.String("target_topic", m.targetTopic),

--- a/internal/input_module.go
+++ b/internal/input_module.go
@@ -72,8 +72,6 @@ func (m *inputModule) Start(ctx context.Context) error {
 		return fmt.Errorf("bento.input %q: no MessagePublisher set; ensure the host injects one", m.name)
 	}
 
-	slog.Info("starting bento input", "module", m.name, "target_topic", m.targetTopic)
-
 	// Build input YAML from the "input" key of the config.
 	inputCfg, ok := m.config["input"].(map[string]any)
 	if !ok {
@@ -114,8 +112,6 @@ func (m *inputModule) Start(ctx context.Context) error {
 			return nil
 		})
 
-		slog.Debug("forwarding message to host eventbus", "module", moduleName, "topic", topic, "size", len(payload))
-
 		_, pubErr := pub.Publish(topic, payload, meta)
 		if pubErr != nil {
 			metrics.RecordError()
@@ -139,7 +135,6 @@ func (m *inputModule) Start(ctx context.Context) error {
 	runCtx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
-	m.health.SetRunning(true)
 	m.metrics.MarkStarted()
 	m.log.LogStreamStart("bento.input",
 		slog.String("target_topic", m.targetTopic),
@@ -148,6 +143,7 @@ func (m *inputModule) Start(ctx context.Context) error {
 
 	go func() {
 		defer close(m.done)
+		m.health.SetRunning(true)
 		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
 			m.health.SetRunning(false)
 			if runErr != nil {
@@ -162,8 +158,6 @@ func (m *inputModule) Start(ctx context.Context) error {
 
 // Stop halts the stream and waits for the goroutine to exit.
 func (m *inputModule) Stop(ctx context.Context) error {
-	slog.Info("stopping bento input", "module", m.name)
-
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
 			m.metrics.RecordError()
@@ -176,7 +170,6 @@ func (m *inputModule) Stop(ctx context.Context) error {
 	}
 	select {
 	case <-m.done:
-		slog.Info("bento input stopped", "module", m.name)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/internal/input_module_test.go
+++ b/internal/input_module_test.go
@@ -269,8 +269,18 @@ func TestInputModule_Health(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 
-	// Allow the stream goroutine to call Run before checking health / stopping.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the module to report healthy rather than relying on a fixed sleep.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		report = m.Health()
+		if report.Status == HealthStatusHealthy {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("module did not become healthy within timeout, last status: %s", report.StatusText)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// After start: healthy
 	report = m.Health()

--- a/internal/input_module_test.go
+++ b/internal/input_module_test.go
@@ -238,6 +238,60 @@ func TestInputModule_PublishMessages(t *testing.T) {
 	}
 }
 
+func TestInputModule_Health(t *testing.T) {
+	pub := &mockMessagePublisher{}
+
+	m, _ := newInputModule("test-input", map[string]any{
+		"target_topic": "test-topic",
+		"input": map[string]any{
+			"generate": map[string]any{
+				"mapping":  `root = {"test": "data"}`,
+				"count":    0,
+				"interval": "1s",
+			},
+		},
+	})
+
+	// Before start: unhealthy
+	report := m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy before start, got %s", report.StatusText)
+	}
+
+	if err := m.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	m.SetMessagePublisher(pub)
+
+	ctx := context.Background()
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Allow the stream goroutine to call Run before checking health / stopping.
+	time.Sleep(50 * time.Millisecond)
+
+	// After start: healthy
+	report = m.Health()
+	if report.Status != HealthStatusHealthy {
+		t.Errorf("expected healthy after start, got %s", report.StatusText)
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// After stop: unhealthy
+	report = m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy after stop, got %s", report.StatusText)
+	}
+}
+
 func TestInputModule_InvalidInputConfig(t *testing.T) {
 	m, _ := newInputModule("test", map[string]any{
 		"target_topic": "test-topic",

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,0 +1,83 @@
+package internal
+
+import (
+	"log/slog"
+	"os"
+)
+
+// bentoLogger is a structured logger wrapper for all bento plugin modules.
+// It uses log/slog from the standard library and attaches component context
+// fields (module type, name) to every log line.
+type bentoLogger struct {
+	logger *slog.Logger
+}
+
+// newLogger creates a bentoLogger for the given component type and name.
+// It uses the default slog handler unless one has been configured globally.
+func newLogger(component, name string) *bentoLogger {
+	base := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	return &bentoLogger{
+		logger: base.With(
+			slog.String("component", component),
+			slog.String("name", name),
+		),
+	}
+}
+
+// LogStreamStart emits an info-level log line when a stream starts.
+func (l *bentoLogger) LogStreamStart(transport string, extraFields ...any) {
+	args := append([]any{slog.String("transport", transport)}, extraFields...)
+	l.logger.Info("stream started", args...)
+}
+
+// LogStreamStop emits an info-level log line when a stream stops.
+// uptimeSeconds is the duration the stream was running.
+func (l *bentoLogger) LogStreamStop(messagesProcessed int64, extraFields ...any) {
+	args := append([]any{slog.Int64("messages_processed", messagesProcessed)}, extraFields...)
+	l.logger.Info("stream stopped", args...)
+}
+
+// LogStreamError emits an error-level log line for a stream error.
+func (l *bentoLogger) LogStreamError(err error, extraFields ...any) {
+	args := append([]any{slog.Any("error", err)}, extraFields...)
+	l.logger.Error("stream error", args...)
+}
+
+// LogMessageProcessed emits a debug-level log line each time a message is processed.
+func (l *bentoLogger) LogMessageProcessed(topic string, extraFields ...any) {
+	args := append([]any{slog.String("topic", topic)}, extraFields...)
+	l.logger.Debug("message processed", args...)
+}
+
+// LogTopicEvent emits an info-level log line for topic lifecycle events
+// (creation, publish, subscribe, etc.).
+func (l *bentoLogger) LogTopicEvent(event, topic string, extraFields ...any) {
+	args := append([]any{
+		slog.String("event", event),
+		slog.String("topic", topic),
+	}, extraFields...)
+	l.logger.Info("topic event", args...)
+}
+
+// LogProcessingStart emits a debug-level log line when a processor step begins.
+func (l *bentoLogger) LogProcessingStart(stepName string, extraFields ...any) {
+	args := append([]any{slog.String("step", stepName)}, extraFields...)
+	l.logger.Debug("processing started", args...)
+}
+
+// LogProcessingComplete emits a debug-level log line when a processor step finishes.
+func (l *bentoLogger) LogProcessingComplete(stepName string, extraFields ...any) {
+	args := append([]any{slog.String("step", stepName)}, extraFields...)
+	l.logger.Debug("processing complete", args...)
+}
+
+// LogProcessingError emits an error-level log line when a processor step fails.
+func (l *bentoLogger) LogProcessingError(stepName string, err error, extraFields ...any) {
+	args := append([]any{
+		slog.String("step", stepName),
+		slog.Any("error", err),
+	}, extraFields...)
+	l.logger.Error("processing error", args...)
+}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"log/slog"
 )
 
@@ -44,6 +45,9 @@ func (l *bentoLogger) LogStreamError(err error, extraFields ...any) {
 
 // LogMessageProcessed emits a debug-level log line each time a message is processed.
 func (l *bentoLogger) LogMessageProcessed(topic string, extraFields ...any) {
+	if !l.logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
 	args := append([]any{slog.String("topic", topic)}, extraFields...)
 	l.logger.Debug("message processed", args...)
 }
@@ -60,12 +64,18 @@ func (l *bentoLogger) LogTopicEvent(event, topic string, extraFields ...any) {
 
 // LogProcessingStart emits a debug-level log line when a processor step begins.
 func (l *bentoLogger) LogProcessingStart(stepName string, extraFields ...any) {
+	if !l.logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
 	args := append([]any{slog.String("step", stepName)}, extraFields...)
 	l.logger.Debug("processing started", args...)
 }
 
 // LogProcessingComplete emits a debug-level log line when a processor step finishes.
 func (l *bentoLogger) LogProcessingComplete(stepName string, extraFields ...any) {
+	if !l.logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
 	args := append([]any{slog.String("step", stepName)}, extraFields...)
 	l.logger.Debug("processing complete", args...)
 }

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"log/slog"
-	"os"
 )
 
 // bentoLogger is a structured logger wrapper for all bento plugin modules.
@@ -13,13 +12,11 @@ type bentoLogger struct {
 }
 
 // newLogger creates a bentoLogger for the given component type and name.
-// It uses the default slog handler unless one has been configured globally.
+// It uses slog.Default() so that any global slog configuration (handler,
+// output, format) set by the caller via slog.SetDefault() is respected.
 func newLogger(component, name string) *bentoLogger {
-	base := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
 	return &bentoLogger{
-		logger: base.With(
+		logger: slog.Default().With(
 			slog.String("component", component),
 			slog.String("name", name),
 		),
@@ -33,7 +30,7 @@ func (l *bentoLogger) LogStreamStart(transport string, extraFields ...any) {
 }
 
 // LogStreamStop emits an info-level log line when a stream stops.
-// uptimeSeconds is the duration the stream was running.
+// messagesProcessed is the total number of messages processed before the stream stopped.
 func (l *bentoLogger) LogStreamStop(messagesProcessed int64, extraFields ...any) {
 	args := append([]any{slog.Int64("messages_processed", messagesProcessed)}, extraFields...)
 	l.logger.Info("stream stopped", args...)

--- a/internal/logger_test.go
+++ b/internal/logger_test.go
@@ -189,6 +189,7 @@ func TestMetricsRecordError(t *testing.T) {
 
 func TestMetricsUptime(t *testing.T) {
 	m := newStreamMetrics()
+	m.MarkStarted()
 	time.Sleep(5 * time.Millisecond)
 	uptime := m.Uptime()
 
@@ -215,6 +216,7 @@ func TestMetricsLastMessageTime(t *testing.T) {
 
 func TestMetricsSnapshot(t *testing.T) {
 	m := newStreamMetrics()
+	m.MarkStarted()
 	m.RecordMessageIn()
 	m.RecordMessageIn()
 	m.RecordMessageOut()

--- a/internal/logger_test.go
+++ b/internal/logger_test.go
@@ -1,0 +1,374 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureLogger returns a bentoLogger that writes JSON records to a buffer so
+// tests can inspect the output.
+func captureLogger(buf *bytes.Buffer, component, name string) *bentoLogger {
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug, // capture everything
+	})
+	return &bentoLogger{
+		logger: slog.New(handler).With(
+			slog.String("component", component),
+			slog.String("name", name),
+		),
+	}
+}
+
+// lastRecord decodes the last JSON line written to buf.
+func lastRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("no log records written")
+	}
+	var record map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &record); err != nil {
+		t.Fatalf("unmarshal last log record: %v", err)
+	}
+	return record
+}
+
+// --- Logger tests ---
+
+func TestLogStreamStart(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "bento.stream", "test-stream")
+	l.LogStreamStart("kafka")
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "stream started" {
+		t.Errorf("expected msg %q, got %q", "stream started", rec["msg"])
+	}
+	if rec["transport"] != "kafka" {
+		t.Errorf("expected transport %q, got %q", "kafka", rec["transport"])
+	}
+	if rec["component"] != "bento.stream" {
+		t.Errorf("expected component %q, got %q", "bento.stream", rec["component"])
+	}
+}
+
+func TestLogStreamStop(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "bento.stream", "test-stream")
+	l.LogStreamStop(42)
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "stream stopped" {
+		t.Errorf("expected msg %q, got %q", "stream stopped", rec["msg"])
+	}
+	// JSON numbers decode as float64.
+	if int64(rec["messages_processed"].(float64)) != 42 {
+		t.Errorf("expected messages_processed 42, got %v", rec["messages_processed"])
+	}
+}
+
+func TestLogStreamError(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "bento.stream", "test-stream")
+	l.LogStreamError(errors.New("connection refused"))
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "stream error" {
+		t.Errorf("expected msg %q, got %q", "stream error", rec["msg"])
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("expected level ERROR, got %v", rec["level"])
+	}
+}
+
+func TestLogMessageProcessed(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "bento.input", "test-input")
+	l.LogMessageProcessed("orders")
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "message processed" {
+		t.Errorf("expected msg %q, got %q", "message processed", rec["msg"])
+	}
+	if rec["topic"] != "orders" {
+		t.Errorf("expected topic %q, got %q", "orders", rec["topic"])
+	}
+}
+
+func TestLogTopicEvent(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "bento.broker", "test-broker")
+	l.LogTopicEvent("stream_created", "payments")
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "topic event" {
+		t.Errorf("expected msg %q, got %q", "topic event", rec["msg"])
+	}
+	if rec["event"] != "stream_created" {
+		t.Errorf("expected event %q, got %q", "stream_created", rec["event"])
+	}
+}
+
+func TestLogProcessingStartComplete(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "step.bento", "my-step")
+	l.LogProcessingStart("my-step")
+	l.LogProcessingComplete("my-step")
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d", len(lines))
+	}
+	var first, last map[string]any
+	if err := json.Unmarshal(lines[0], &first); err != nil {
+		t.Fatalf("unmarshal first: %v", err)
+	}
+	if err := json.Unmarshal(lines[1], &last); err != nil {
+		t.Fatalf("unmarshal last: %v", err)
+	}
+	if first["msg"] != "processing started" {
+		t.Errorf("expected %q, got %q", "processing started", first["msg"])
+	}
+	if last["msg"] != "processing complete" {
+		t.Errorf("expected %q, got %q", "processing complete", last["msg"])
+	}
+}
+
+func TestLogProcessingError(t *testing.T) {
+	var buf bytes.Buffer
+	l := captureLogger(&buf, "step.bento", "my-step")
+	l.LogProcessingError("my-step", errors.New("bloblang parse failed"))
+
+	rec := lastRecord(t, &buf)
+	if rec["msg"] != "processing error" {
+		t.Errorf("expected msg %q, got %q", "processing error", rec["msg"])
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("expected level ERROR, got %v", rec["level"])
+	}
+}
+
+// --- Metrics tests ---
+
+func TestMetricsRecordMessageIn(t *testing.T) {
+	m := newStreamMetrics()
+	m.RecordMessageIn()
+	m.RecordMessageIn()
+
+	if m.MessagesIn() != 2 {
+		t.Errorf("expected MessagesIn=2, got %d", m.MessagesIn())
+	}
+	if m.MessagesOut() != 0 {
+		t.Errorf("expected MessagesOut=0, got %d", m.MessagesOut())
+	}
+}
+
+func TestMetricsRecordMessageOut(t *testing.T) {
+	m := newStreamMetrics()
+	m.RecordMessageOut()
+
+	if m.MessagesOut() != 1 {
+		t.Errorf("expected MessagesOut=1, got %d", m.MessagesOut())
+	}
+}
+
+func TestMetricsRecordError(t *testing.T) {
+	m := newStreamMetrics()
+	m.RecordError()
+	m.RecordError()
+
+	if m.Errors() != 2 {
+		t.Errorf("expected Errors=2, got %d", m.Errors())
+	}
+}
+
+func TestMetricsUptime(t *testing.T) {
+	m := newStreamMetrics()
+	time.Sleep(5 * time.Millisecond)
+	uptime := m.Uptime()
+
+	if uptime < 5*time.Millisecond {
+		t.Errorf("expected uptime >= 5ms, got %v", uptime)
+	}
+}
+
+func TestMetricsLastMessageTime(t *testing.T) {
+	m := newStreamMetrics()
+	if !m.LastMessageTime().IsZero() {
+		t.Error("expected zero LastMessageTime before any messages")
+	}
+
+	before := time.Now()
+	m.RecordMessageIn()
+	after := time.Now()
+
+	lmt := m.LastMessageTime()
+	if lmt.Before(before) || lmt.After(after) {
+		t.Errorf("LastMessageTime %v not in range [%v, %v]", lmt, before, after)
+	}
+}
+
+func TestMetricsSnapshot(t *testing.T) {
+	m := newStreamMetrics()
+	m.RecordMessageIn()
+	m.RecordMessageIn()
+	m.RecordMessageOut()
+	m.RecordError()
+
+	snap := m.Snapshot()
+	if snap.MessagesIn != 2 {
+		t.Errorf("expected MessagesIn=2, got %d", snap.MessagesIn)
+	}
+	if snap.MessagesOut != 1 {
+		t.Errorf("expected MessagesOut=1, got %d", snap.MessagesOut)
+	}
+	if snap.Errors != 1 {
+		t.Errorf("expected Errors=1, got %d", snap.Errors)
+	}
+	if snap.Uptime <= 0 {
+		t.Errorf("expected positive Uptime, got %v", snap.Uptime)
+	}
+	if snap.LastMessageTime.IsZero() {
+		t.Error("expected non-zero LastMessageTime")
+	}
+}
+
+func TestMetricsConcurrentUpdates(t *testing.T) {
+	m := newStreamMetrics()
+	const goroutines = 50
+	const msgsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < msgsPerGoroutine; j++ {
+				m.RecordMessageIn()
+				m.RecordMessageOut()
+				m.RecordError()
+			}
+		}()
+	}
+	wg.Wait()
+
+	expected := int64(goroutines * msgsPerGoroutine)
+	if m.MessagesIn() != expected {
+		t.Errorf("MessagesIn: expected %d, got %d", expected, m.MessagesIn())
+	}
+	if m.MessagesOut() != expected {
+		t.Errorf("MessagesOut: expected %d, got %d", expected, m.MessagesOut())
+	}
+	if m.Errors() != expected {
+		t.Errorf("Errors: expected %d, got %d", expected, m.Errors())
+	}
+}
+
+// --- Health tests ---
+
+func TestHealthStatusString(t *testing.T) {
+	cases := []struct {
+		status HealthStatus
+		want   string
+	}{
+		{HealthStatusHealthy, "healthy"},
+		{HealthStatusDegraded, "degraded"},
+		{HealthStatusUnhealthy, "unhealthy"},
+	}
+	for _, c := range cases {
+		if got := c.status.String(); got != c.want {
+			t.Errorf("HealthStatus(%d).String() = %q, want %q", c.status, got, c.want)
+		}
+	}
+}
+
+func TestHealthTracker_InitiallyUnhealthy(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+
+	report := h.Report()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected Unhealthy before SetRunning(true), got %v", report.Status)
+	}
+}
+
+func TestHealthTracker_HealthyWhenRunning(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+	h.SetRunning(true)
+
+	report := h.Report()
+	if report.Status != HealthStatusHealthy {
+		t.Errorf("expected Healthy after SetRunning(true) with no errors, got %v", report.Status)
+	}
+}
+
+func TestHealthTracker_DegradedOnError(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+	h.SetRunning(true)
+	m.RecordError()
+
+	report := h.Report()
+	if report.Status != HealthStatusDegraded {
+		t.Errorf("expected Degraded after error, got %v", report.Status)
+	}
+	if report.Errors != 1 {
+		t.Errorf("expected Errors=1 in report, got %d", report.Errors)
+	}
+}
+
+func TestHealthTracker_UnhealthyAfterStop(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+	h.SetRunning(true)
+	h.SetRunning(false)
+
+	report := h.Report()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected Unhealthy after stop, got %v", report.Status)
+	}
+}
+
+func TestHealthTracker_ReportContainsMetrics(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+	h.SetRunning(true)
+	m.RecordMessageIn()
+	m.RecordMessageOut()
+
+	report := h.Report()
+	if report.MessagesIn != 1 {
+		t.Errorf("expected MessagesIn=1, got %d", report.MessagesIn)
+	}
+	if report.MessagesOut != 1 {
+		t.Errorf("expected MessagesOut=1, got %d", report.MessagesOut)
+	}
+	if report.StatusText != "healthy" {
+		t.Errorf("expected status_text=healthy, got %q", report.StatusText)
+	}
+}
+
+func TestHealthTracker_ConcurrentAccess(t *testing.T) {
+	m := newStreamMetrics()
+	h := newHealthTracker(m)
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			h.SetRunning(i%2 == 0)
+			m.RecordMessageIn()
+			_ = h.Report()
+		}()
+	}
+	wg.Wait() // should not race
+}

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -8,7 +8,7 @@ import (
 
 // StreamMetrics tracks runtime statistics for a single stream or module.
 // All counter operations are thread-safe via atomic primitives; the
-// startTime/lastMessageTime fields are guarded by a small mutex.
+// startTime/stopTime/lastMessageTime fields are guarded by a small mutex.
 type StreamMetrics struct {
 	messagesIn  atomic.Int64
 	messagesOut atomic.Int64
@@ -16,15 +16,34 @@ type StreamMetrics struct {
 
 	mu              sync.Mutex
 	startTime       time.Time
+	stopTime        time.Time
 	lastMessageTime time.Time
 }
 
-// newStreamMetrics creates a StreamMetrics instance with the start time set
-// to the current wall clock.
+// newStreamMetrics creates a new StreamMetrics instance. Call MarkStarted
+// when the associated module begins running.
 func newStreamMetrics() *StreamMetrics {
-	m := &StreamMetrics{}
+	return &StreamMetrics{}
+}
+
+// MarkStarted records the moment the stream begins running, resetting any
+// previously frozen stop time. Call this from module Start().
+func (m *StreamMetrics) MarkStarted() {
+	m.mu.Lock()
 	m.startTime = time.Now()
-	return m
+	m.stopTime = time.Time{}
+	m.mu.Unlock()
+}
+
+// MarkStopped freezes the uptime at the current wall clock. After this call
+// Uptime() returns a stable value rather than continuing to grow. Call this
+// from module Stop().
+func (m *StreamMetrics) MarkStopped() {
+	m.mu.Lock()
+	if !m.startTime.IsZero() {
+		m.stopTime = time.Now()
+	}
+	m.mu.Unlock()
 }
 
 // RecordMessageIn increments the inbound message counter and updates
@@ -65,12 +84,17 @@ func (m *StreamMetrics) Errors() int64 {
 	return m.errors.Load()
 }
 
-// Uptime returns how long the stream has been running since Start was called.
+// Uptime returns how long the stream was running. If MarkStopped has been
+// called the duration is frozen; otherwise it grows from MarkStarted.
+// Returns 0 if MarkStarted has not been called.
 func (m *StreamMetrics) Uptime() time.Duration {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.startTime.IsZero() {
 		return 0
+	}
+	if !m.stopTime.IsZero() {
+		return m.stopTime.Sub(m.startTime)
 	}
 	return time.Since(m.startTime)
 }
@@ -98,7 +122,11 @@ func (m *StreamMetrics) Snapshot() MetricsSnapshot {
 	m.mu.Lock()
 	uptime := time.Duration(0)
 	if !m.startTime.IsZero() {
-		uptime = time.Since(m.startTime)
+		if !m.stopTime.IsZero() {
+			uptime = m.stopTime.Sub(m.startTime)
+		} else {
+			uptime = time.Since(m.startTime)
+		}
 	}
 	lastMsg := m.lastMessageTime
 	m.mu.Unlock()

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -23,9 +23,7 @@ type StreamMetrics struct {
 // to the current wall clock.
 func newStreamMetrics() *StreamMetrics {
 	m := &StreamMetrics{}
-	m.mu.Lock()
 	m.startTime = time.Now()
-	m.mu.Unlock()
 	return m
 }
 

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -1,0 +1,115 @@
+package internal
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// StreamMetrics tracks runtime statistics for a single stream or module.
+// All counter operations are thread-safe via atomic primitives; the
+// startTime/lastMessageTime fields are guarded by a small mutex.
+type StreamMetrics struct {
+	messagesIn  atomic.Int64
+	messagesOut atomic.Int64
+	errors      atomic.Int64
+
+	mu              sync.Mutex
+	startTime       time.Time
+	lastMessageTime time.Time
+}
+
+// newStreamMetrics creates a StreamMetrics instance with the start time set
+// to the current wall clock.
+func newStreamMetrics() *StreamMetrics {
+	m := &StreamMetrics{}
+	m.mu.Lock()
+	m.startTime = time.Now()
+	m.mu.Unlock()
+	return m
+}
+
+// RecordMessageIn increments the inbound message counter and updates
+// lastMessageTime.
+func (m *StreamMetrics) RecordMessageIn() {
+	m.messagesIn.Add(1)
+	m.mu.Lock()
+	m.lastMessageTime = time.Now()
+	m.mu.Unlock()
+}
+
+// RecordMessageOut increments the outbound message counter and updates
+// lastMessageTime.
+func (m *StreamMetrics) RecordMessageOut() {
+	m.messagesOut.Add(1)
+	m.mu.Lock()
+	m.lastMessageTime = time.Now()
+	m.mu.Unlock()
+}
+
+// RecordError increments the error counter.
+func (m *StreamMetrics) RecordError() {
+	m.errors.Add(1)
+}
+
+// MessagesIn returns the total inbound message count.
+func (m *StreamMetrics) MessagesIn() int64 {
+	return m.messagesIn.Load()
+}
+
+// MessagesOut returns the total outbound message count.
+func (m *StreamMetrics) MessagesOut() int64 {
+	return m.messagesOut.Load()
+}
+
+// Errors returns the total error count.
+func (m *StreamMetrics) Errors() int64 {
+	return m.errors.Load()
+}
+
+// Uptime returns how long the stream has been running since Start was called.
+func (m *StreamMetrics) Uptime() time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.startTime.IsZero() {
+		return 0
+	}
+	return time.Since(m.startTime)
+}
+
+// LastMessageTime returns the time the last message was recorded.
+// Returns the zero value if no messages have been recorded yet.
+func (m *StreamMetrics) LastMessageTime() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastMessageTime
+}
+
+// MetricsSnapshot is a point-in-time copy of StreamMetrics that can be
+// safely marshalled or logged without holding any locks.
+type MetricsSnapshot struct {
+	MessagesIn      int64         `json:"messages_in"`
+	MessagesOut     int64         `json:"messages_out"`
+	Errors          int64         `json:"errors"`
+	Uptime          time.Duration `json:"uptime_ns"`
+	LastMessageTime time.Time     `json:"last_message_time"`
+}
+
+// Snapshot returns a consistent point-in-time copy of the metrics.
+func (m *StreamMetrics) Snapshot() MetricsSnapshot {
+	m.mu.Lock()
+	uptime := time.Duration(0)
+	if !m.startTime.IsZero() {
+		uptime = time.Since(m.startTime)
+	}
+	lastMsg := m.lastMessageTime
+	m.mu.Unlock()
+
+	return MetricsSnapshot{
+		MessagesIn:      m.messagesIn.Load(),
+		MessagesOut:     m.messagesOut.Load(),
+		Errors:          m.errors.Load(),
+		Uptime:          uptime,
+		LastMessageTime: lastMsg,
+	}
+}

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -8,16 +8,19 @@ import (
 
 // StreamMetrics tracks runtime statistics for a single stream or module.
 // All counter operations are thread-safe via atomic primitives; the
-// startTime/stopTime/lastMessageTime fields are guarded by a small mutex.
+// startTime/stopTime fields are guarded by a small mutex, while
+// lastMessageTimeNs is stored atomically (Unix nanoseconds) to avoid
+// mutex contention on hot message paths.
 type StreamMetrics struct {
 	messagesIn  atomic.Int64
 	messagesOut atomic.Int64
 	errors      atomic.Int64
 
-	mu              sync.Mutex
-	startTime       time.Time
-	stopTime        time.Time
-	lastMessageTime time.Time
+	lastMessageTimeNs atomic.Int64
+
+	mu        sync.Mutex
+	startTime time.Time
+	stopTime  time.Time
 }
 
 // newStreamMetrics creates a new StreamMetrics instance. Call MarkStarted
@@ -47,21 +50,17 @@ func (m *StreamMetrics) MarkStopped() {
 }
 
 // RecordMessageIn increments the inbound message counter and updates
-// lastMessageTime.
+// lastMessageTimeNs atomically.
 func (m *StreamMetrics) RecordMessageIn() {
 	m.messagesIn.Add(1)
-	m.mu.Lock()
-	m.lastMessageTime = time.Now()
-	m.mu.Unlock()
+	m.lastMessageTimeNs.Store(time.Now().UnixNano())
 }
 
 // RecordMessageOut increments the outbound message counter and updates
-// lastMessageTime.
+// lastMessageTimeNs atomically.
 func (m *StreamMetrics) RecordMessageOut() {
 	m.messagesOut.Add(1)
-	m.mu.Lock()
-	m.lastMessageTime = time.Now()
-	m.mu.Unlock()
+	m.lastMessageTimeNs.Store(time.Now().UnixNano())
 }
 
 // RecordError increments the error counter.
@@ -102,9 +101,11 @@ func (m *StreamMetrics) Uptime() time.Duration {
 // LastMessageTime returns the time the last message was recorded.
 // Returns the zero value if no messages have been recorded yet.
 func (m *StreamMetrics) LastMessageTime() time.Time {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.lastMessageTime
+	ns := m.lastMessageTimeNs.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
 }
 
 // MetricsSnapshot is a point-in-time copy of StreamMetrics that can be
@@ -128,8 +129,12 @@ func (m *StreamMetrics) Snapshot() MetricsSnapshot {
 			uptime = time.Since(m.startTime)
 		}
 	}
-	lastMsg := m.lastMessageTime
 	m.mu.Unlock()
+
+	var lastMsg time.Time
+	if ns := m.lastMessageTimeNs.Load(); ns != 0 {
+		lastMsg = time.Unix(0, ns)
+	}
 
 	return MetricsSnapshot{
 		MessagesIn:      m.messagesIn.Load(),

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -21,6 +21,9 @@ type outputModule struct {
 	producerFn   service.MessageHandlerFunc
 	cancel       context.CancelFunc
 	done         chan struct{}
+	log          *bentoLogger
+	metrics      *StreamMetrics
+	health       *healthTracker
 }
 
 // SetMessagePublisher satisfies the MessageAwareModule interface.
@@ -33,10 +36,14 @@ func (m *outputModule) SetMessageSubscriber(sub sdk.MessageSubscriber) {
 }
 
 func newOutputModule(name string, config map[string]any) (*outputModule, error) {
+	metrics := newStreamMetrics()
 	return &outputModule{
-		name:   name,
-		config: config,
-		done:   make(chan struct{}),
+		name:    name,
+		config:  config,
+		done:    make(chan struct{}),
+		log:     newLogger("bento.output", name),
+		metrics: metrics,
+		health:  newHealthTracker(metrics),
 	}, nil
 }
 
@@ -104,16 +111,27 @@ func (m *outputModule) Start(ctx context.Context) error {
 	moduleName := m.name
 	producerFnRef := m.producerFn
 
+	m.health.SetRunning(true)
+	m.log.LogStreamStart("bento.output",
+		slog.String("source_topic", m.sourceTopic),
+		slog.String("source_broker", m.sourceBroker),
+	)
+
 	go func() {
 		defer close(m.done)
-		if err := stream.Run(runCtx); err != nil && runCtx.Err() == nil {
-			slog.Error("bento output stream failed", "error", err, "module", moduleName)
+		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
+			m.metrics.RecordError()
+			m.log.LogStreamError(runErr)
 		}
 	}()
 
-	// Subscribe after launching the goroutine so that messages flow into the
-	// running stream. If Subscribe fails, cancel the context so the goroutine
-	// exits, wait for it to finish, then return the error.
+	// Subscribe to the host EventBus topic. When messages arrive, forward them
+	// to the Bento producer.
+	producerFnRef := m.producerFn
+	metrics := m.metrics
+	log := m.log
+	sourceTopic := m.sourceTopic
+
 	if err := m.subscriber.Subscribe(m.sourceTopic, func(payload []byte, metadata map[string]string) error {
 		slog.Debug("sending message to bento output", "module", moduleName, "topic", m.sourceTopic, "size", len(payload))
 
@@ -121,11 +139,14 @@ func (m *outputModule) Start(ctx context.Context) error {
 		for k, v := range metadata {
 			msg.MetaSet(k, v)
 		}
-		sendErr := producerFnRef(runCtx, msg)
-		if sendErr != nil {
-			slog.Error("failed to send message to bento output", "error", sendErr, "module", moduleName)
+		if sendErr := producerFnRef(runCtx, msg); sendErr != nil {
+			metrics.RecordError()
+			log.LogStreamError(sendErr, slog.String("phase", "forward"))
+			return sendErr
 		}
-		return sendErr
+		metrics.RecordMessageIn()
+		log.LogMessageProcessed(sourceTopic)
+		return nil
 	}); err != nil {
 		cancel()
 		<-m.done
@@ -148,7 +169,8 @@ func (m *outputModule) Stop(ctx context.Context) error {
 	}
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
-			slog.Error("error stopping bento output", "error", err, "module", m.name)
+			m.metrics.RecordError()
+			m.log.LogStreamError(err, slog.String("phase", "stop"))
 			return fmt.Errorf("bento.output %q: stop: %w", m.name, err)
 		}
 	}
@@ -161,5 +183,19 @@ func (m *outputModule) Stop(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
+	m.health.SetRunning(false)
+	snap := m.metrics.Snapshot()
+	m.log.LogStreamStop(snap.MessagesIn,
+		slog.String("source_topic", m.sourceTopic),
+		slog.Duration("uptime", snap.Uptime),
+		slog.Int64("errors", snap.Errors),
+	)
+
 	return nil
+}
+
+// Health returns the current health report for this output module.
+func (m *outputModule) Health() HealthReport {
+	return m.health.Report()
 }

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -111,22 +111,9 @@ func (m *outputModule) Start(ctx context.Context) error {
 	moduleName := m.name
 	producerFnRef := m.producerFn
 
-	m.health.SetRunning(true)
-	m.log.LogStreamStart("bento.output",
-		slog.String("source_topic", m.sourceTopic),
-		slog.String("source_broker", m.sourceBroker),
-	)
-
-	go func() {
-		defer close(m.done)
-		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
-			m.metrics.RecordError()
-			m.log.LogStreamError(runErr)
-		}
-	}()
-
-	// Subscribe to the host EventBus topic. When messages arrive, forward them
-	// to the Bento producer.
+	// Subscribe to the host EventBus topic before starting the stream. When
+	// messages arrive, forward them to the Bento producer. Subscribing first
+	// avoids leaking the stream goroutine if Subscribe returns an error.
 	producerFnRef := m.producerFn
 	metrics := m.metrics
 	log := m.log
@@ -148,12 +135,28 @@ func (m *outputModule) Start(ctx context.Context) error {
 		log.LogMessageProcessed(sourceTopic)
 		return nil
 	}); err != nil {
+		// Cancel the context since the stream goroutine was never launched.
 		cancel()
-		<-m.done
 		return fmt.Errorf("bento.output %q: subscribe to topic %q: %w", m.name, m.sourceTopic, err)
 	}
 
-	slog.Info("bento output running", "module", m.name)
+	m.health.SetRunning(true)
+	m.metrics.MarkStarted()
+	m.log.LogStreamStart("bento.output",
+		slog.String("source_topic", m.sourceTopic),
+		slog.String("source_broker", m.sourceBroker),
+	)
+
+	go func() {
+		defer close(m.done)
+		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
+			m.health.SetRunning(false)
+			if runErr != nil {
+				m.metrics.RecordError()
+				m.log.LogStreamError(runErr)
+			}
+		}
+	}()
 
 	return nil
 }
@@ -185,6 +188,7 @@ func (m *outputModule) Stop(ctx context.Context) error {
 	}
 
 	m.health.SetRunning(false)
+	m.metrics.MarkStopped()
 	snap := m.metrics.Snapshot()
 	m.log.LogStreamStop(snap.MessagesIn,
 		slog.String("source_topic", m.sourceTopic),

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -74,8 +74,6 @@ func (m *outputModule) Start(ctx context.Context) error {
 		return fmt.Errorf("bento.output %q: no MessageSubscriber set; ensure the host injects one", m.name)
 	}
 
-	slog.Info("starting bento output", "module", m.name, "source_topic", m.sourceTopic)
-
 	// Build output YAML from the "output" key of the config.
 	outputCfg, ok := m.config["output"].(map[string]any)
 	if !ok {
@@ -106,10 +104,6 @@ func (m *outputModule) Start(ctx context.Context) error {
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-	m.done = make(chan struct{})
-
-	moduleName := m.name
-	producerFnRef := m.producerFn
 
 	// Subscribe to the host EventBus topic before starting the stream. When
 	// messages arrive, forward them to the Bento producer. Subscribing first
@@ -120,8 +114,6 @@ func (m *outputModule) Start(ctx context.Context) error {
 	sourceTopic := m.sourceTopic
 
 	if err := m.subscriber.Subscribe(m.sourceTopic, func(payload []byte, metadata map[string]string) error {
-		slog.Debug("sending message to bento output", "module", moduleName, "topic", m.sourceTopic, "size", len(payload))
-
 		msg := service.NewMessage(payload)
 		for k, v := range metadata {
 			msg.MetaSet(k, v)
@@ -142,7 +134,6 @@ func (m *outputModule) Start(ctx context.Context) error {
 		return fmt.Errorf("bento.output %q: subscribe to topic %q: %w", m.name, m.sourceTopic, err)
 	}
 
-	m.health.SetRunning(true)
 	m.metrics.MarkStarted()
 	m.log.LogStreamStart("bento.output",
 		slog.String("source_topic", m.sourceTopic),
@@ -151,6 +142,7 @@ func (m *outputModule) Start(ctx context.Context) error {
 
 	go func() {
 		defer close(m.done)
+		m.health.SetRunning(true)
 		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
 			m.health.SetRunning(false)
 			if runErr != nil {
@@ -165,12 +157,8 @@ func (m *outputModule) Start(ctx context.Context) error {
 
 // Stop unsubscribes, stops the stream, and waits for the goroutine to exit.
 func (m *outputModule) Stop(ctx context.Context) error {
-	slog.Info("stopping bento output", "module", m.name)
-
 	if m.subscriber != nil {
-		if err := m.subscriber.Unsubscribe(m.sourceTopic); err != nil {
-			slog.Error("error unsubscribing from source topic", "error", err, "module", m.name, "topic", m.sourceTopic)
-		}
+		_ = m.subscriber.Unsubscribe(m.sourceTopic)
 	}
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
@@ -184,7 +172,6 @@ func (m *outputModule) Stop(ctx context.Context) error {
 	}
 	select {
 	case <-m.done:
-		slog.Info("bento output stopped", "module", m.name)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -66,6 +66,16 @@ func (m *outputModule) Init() error {
 	return nil
 }
 
+// outputTransportType extracts the top-level key from the output config map,
+// which represents the actual Bento output type (e.g. "kafka", "drop").
+// Falls back to "bento.output" if the type cannot be determined.
+func outputTransportType(outputCfg map[string]any) string {
+	for k := range outputCfg {
+		return k
+	}
+	return "bento.output"
+}
+
 // Start builds the Bento output stream, registers a producer func, and
 // subscribes to the host EventBus topic. Incoming messages are fed into Bento
 // for delivery.
@@ -73,6 +83,9 @@ func (m *outputModule) Start(ctx context.Context) error {
 	if m.subscriber == nil {
 		return fmt.Errorf("bento.output %q: no MessageSubscriber set; ensure the host injects one", m.name)
 	}
+
+	// Reinitialize done so the module can be restarted after a previous Stop.
+	m.done = make(chan struct{})
 
 	// Build output YAML from the "output" key of the config.
 	outputCfg, ok := m.config["output"].(map[string]any)
@@ -135,7 +148,9 @@ func (m *outputModule) Start(ctx context.Context) error {
 	}
 
 	m.metrics.MarkStarted()
-	m.log.LogStreamStart("bento.output",
+	// Extract the actual output transport type (e.g. "kafka", "drop") for
+	// more informative log output instead of the generic module type string.
+	m.log.LogStreamStart(outputTransportType(outputCfg),
 		slog.String("source_topic", m.sourceTopic),
 		slog.String("source_broker", m.sourceBroker),
 	)

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -135,8 +135,10 @@ func (m *outputModule) Start(ctx context.Context) error {
 		log.LogMessageProcessed(sourceTopic)
 		return nil
 	}); err != nil {
-		// Cancel the context since the stream goroutine was never launched.
+		// Cancel the context and stop the built stream to avoid a resource leak,
+		// since the stream goroutine was never launched.
 		cancel()
+		_ = stream.Stop(ctx)
 		return fmt.Errorf("bento.output %q: subscribe to topic %q: %w", m.name, m.sourceTopic, err)
 	}
 

--- a/internal/output_module_test.go
+++ b/internal/output_module_test.go
@@ -267,8 +267,18 @@ func TestOutputModule_Health(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 
-	// Allow the stream goroutine to call Run before checking health / stopping.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the module becomes healthy or time out.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		report = m.Health()
+		if report.Status == HealthStatusHealthy {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("module did not become healthy within timeout, last status: %s", report.StatusText)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// After start: healthy
 	report = m.Health()

--- a/internal/output_module_test.go
+++ b/internal/output_module_test.go
@@ -240,6 +240,56 @@ func TestOutputModule_SubscribeAndReceiveMessages(t *testing.T) {
 	}
 }
 
+func TestOutputModule_Health(t *testing.T) {
+	sub := newMockMessageSubscriber()
+
+	m, _ := newOutputModule("test-output", map[string]any{
+		"source_topic": "test-topic",
+		"output": map[string]any{
+			"drop": map[string]any{},
+		},
+	})
+
+	// Before start: unhealthy
+	report := m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy before start, got %s", report.StatusText)
+	}
+
+	if err := m.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	m.SetMessageSubscriber(sub)
+
+	ctx := context.Background()
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Allow the stream goroutine to call Run before checking health / stopping.
+	time.Sleep(50 * time.Millisecond)
+
+	// After start: healthy
+	report = m.Health()
+	if report.Status != HealthStatusHealthy {
+		t.Errorf("expected healthy after start, got %s", report.StatusText)
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// After stop: unhealthy
+	report = m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy after stop, got %s", report.StatusText)
+	}
+}
+
 func TestOutputModule_InvalidOutputConfig(t *testing.T) {
 	m, _ := newOutputModule("test", map[string]any{
 		"source_topic": "test-topic",

--- a/internal/output_module_test.go
+++ b/internal/output_module_test.go
@@ -220,8 +220,17 @@ func TestOutputModule_SubscribeAndReceiveMessages(t *testing.T) {
 		t.Errorf("SimulateMessage() error = %v", err)
 	}
 
-	// Allow time for processing
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the module has processed the message rather than sleeping.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if m.metrics.Snapshot().MessagesIn >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("message was not processed within timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/internal/processor_step.go
+++ b/internal/processor_step.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
 	"github.com/warpstreamlabs/bento/v4/public/service"
@@ -90,12 +89,9 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 	resultCh := make(chan map[string]any, 1)
 	errCh := make(chan error, 1)
 
-	stepName := s.name
-
 	if err := builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
 		raw, err := msg.AsBytes()
 		if err != nil {
-			slog.Error("failed to read processed message", "error", err, "step", stepName)
 			errCh <- fmt.Errorf("read processed message: %w", err)
 			return err
 		}
@@ -119,17 +115,22 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 
 	// Run stream in background; stop it once we've received the result.
 	streamCtx, streamCancel := context.WithCancel(ctx)
-	defer streamCancel()
 
 	streamDone := make(chan error, 1)
 	go func() {
 		streamDone <- stream.Run(streamCtx)
 	}()
 
+	// Ensure stream is stopped and drained on all exit paths from this point.
+	defer func() {
+		streamCancel()
+		_ = stream.Stop(context.Background())
+		<-streamDone
+	}()
+
 	// Send the input message.
 	inputMsg := service.NewMessage(inputBytes)
 	if err := producerFn(ctx, inputMsg); err != nil {
-		streamCancel()
 		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: send input message: %w", s.name, err)
 	}
@@ -138,23 +139,13 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 	var output map[string]any
 	select {
 	case output = <-resultCh:
-		slog.Debug("bento step completed", "step", s.name)
 	case err := <-errCh:
-		streamCancel()
 		s.log.LogProcessingError(s.name, err)
 		return nil, err
 	case <-ctx.Done():
-		streamCancel()
 		s.log.LogProcessingError(s.name, ctx.Err())
 		return nil, ctx.Err()
 	}
-
-	// Stop the stream gracefully.
-	if stopErr := stream.Stop(ctx); stopErr != nil {
-		_ = stopErr // best-effort
-	}
-	streamCancel()
-	<-streamDone
 
 	s.log.LogProcessingComplete(s.name)
 	return &sdk.StepResult{Output: output}, nil

--- a/internal/processor_step.go
+++ b/internal/processor_step.go
@@ -15,10 +15,15 @@ type processorStep struct {
 	name       string
 	config     map[string]any
 	processors string // YAML for the processors section
+	log        *bentoLogger
 }
 
 func newProcessorStep(name string, config map[string]any) (*processorStep, error) {
-	s := &processorStep{name: name, config: config}
+	s := &processorStep{
+		name:   name,
+		config: config,
+		log:    newLogger("step.bento", name),
+	}
 
 	// Extract the "processors" key if present; it can be a YAML string or a map.
 	switch v := config["processors"].(type) {
@@ -43,7 +48,7 @@ func newProcessorStep(name string, config map[string]any) (*processorStep, error
 // Execute runs the input data through the configured Bento processors and
 // returns the transformed output.
 func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any, _ map[string]map[string]any, current map[string]any, _ map[string]any) (*sdk.StepResult, error) {
-	slog.Debug("executing bento step", "step", s.name)
+	s.log.LogProcessingStart(s.name)
 
 	// Merge current + triggerData as the step input.
 	input := make(map[string]any, len(triggerData)+len(current))
@@ -56,13 +61,13 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 
 	// If no processors configured, pass data through unchanged.
 	if s.processors == "" {
-		slog.Debug("bento step passthrough (no processors)", "step", s.name)
+		s.log.LogProcessingComplete(s.name)
 		return &sdk.StepResult{Output: input}, nil
 	}
 
 	inputBytes, err := json.Marshal(input)
 	if err != nil {
-		slog.Error("failed to marshal step input", "error", err, "step", s.name)
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: marshal input: %w", s.name, err)
 	}
 
@@ -72,10 +77,12 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 
 	producerFn, err := builder.AddProducerFunc()
 	if err != nil {
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: add producer: %w", s.name, err)
 	}
 
 	if err := builder.AddProcessorYAML(s.processors); err != nil {
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: add processor yaml: %w", s.name, err)
 	}
 
@@ -100,11 +107,13 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 		resultCh <- out
 		return nil
 	}); err != nil {
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: add consumer: %w", s.name, err)
 	}
 
 	stream, err := builder.Build()
 	if err != nil {
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: build stream: %w", s.name, err)
 	}
 
@@ -121,7 +130,7 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 	inputMsg := service.NewMessage(inputBytes)
 	if err := producerFn(ctx, inputMsg); err != nil {
 		streamCancel()
-		slog.Error("failed to send message to bento processor", "error", err, "step", s.name)
+		s.log.LogProcessingError(s.name, err)
 		return nil, fmt.Errorf("step.bento %q: send input message: %w", s.name, err)
 	}
 
@@ -132,9 +141,11 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 		slog.Debug("bento step completed", "step", s.name)
 	case err := <-errCh:
 		streamCancel()
+		s.log.LogProcessingError(s.name, err)
 		return nil, err
 	case <-ctx.Done():
 		streamCancel()
+		s.log.LogProcessingError(s.name, ctx.Err())
 		return nil, ctx.Err()
 	}
 
@@ -145,5 +156,6 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 	streamCancel()
 	<-streamDone
 
+	s.log.LogProcessingComplete(s.name)
 	return &sdk.StepResult{Output: output}, nil
 }

--- a/internal/processor_step.go
+++ b/internal/processor_step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
 	"github.com/warpstreamlabs/bento/v4/public/service"
@@ -85,14 +86,18 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 		return nil, fmt.Errorf("step.bento %q: add processor yaml: %w", s.name, err)
 	}
 
-	// Collect results via consumer.
+	// Collect results via consumer. sync.Once ensures only the first message
+	// (or error) is captured; if the processor emits multiple messages the
+	// remaining ones are acknowledged and discarded rather than blocking the
+	// fixed-size channel and deadlocking the consumer goroutine.
 	resultCh := make(chan map[string]any, 1)
 	errCh := make(chan error, 1)
+	var once sync.Once
 
 	if err := builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
 		raw, err := msg.AsBytes()
 		if err != nil {
-			errCh <- fmt.Errorf("read processed message: %w", err)
+			once.Do(func() { errCh <- fmt.Errorf("read processed message: %w", err) })
 			return err
 		}
 		var out map[string]any
@@ -100,7 +105,7 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 			// Not JSON — store raw string under "output".
 			out = map[string]any{"output": string(raw)}
 		}
-		resultCh <- out
+		once.Do(func() { resultCh <- out })
 		return nil
 	}); err != nil {
 		s.log.LogProcessingError(s.name, err)
@@ -122,10 +127,15 @@ func (s *processorStep) Execute(ctx context.Context, triggerData map[string]any,
 	}()
 
 	// Ensure stream is stopped and drained on all exit paths from this point.
+	// Use a select on ctx.Done() when waiting for the stream goroutine so that
+	// a cancelled parent context does not cause an unconditional deadlock here.
 	defer func() {
 		streamCancel()
 		_ = stream.Stop(context.Background())
-		<-streamDone
+		select {
+		case <-streamDone:
+		case <-ctx.Done():
+		}
 	}()
 
 	// Send the input message.

--- a/internal/stream_module.go
+++ b/internal/stream_module.go
@@ -132,9 +132,8 @@ func (m *streamModule) Stop(ctx context.Context) error {
 
 	m.health.SetRunning(false)
 	snap := m.metrics.Snapshot()
-	m.log.LogStreamStop(snap.MessagesIn,
+	m.log.LogStreamStop(snap.Errors,
 		slog.Duration("uptime", snap.Uptime),
-		slog.Int64("errors", snap.Errors),
 	)
 
 	return nil

--- a/internal/stream_module.go
+++ b/internal/stream_module.go
@@ -92,6 +92,7 @@ func (m *streamModule) Start(ctx context.Context) error {
 	m.cancel = cancel
 
 	m.health.SetRunning(true)
+	m.metrics.MarkStarted()
 
 	m.log.LogStreamStart("bento",
 		slog.Int("config_keys", len(m.config)),
@@ -99,9 +100,12 @@ func (m *streamModule) Start(ctx context.Context) error {
 
 	go func() {
 		defer close(m.done)
-		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
-			m.metrics.RecordError()
-			m.log.LogStreamError(runErr)
+		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
+			m.health.SetRunning(false)
+			if runErr != nil {
+				m.metrics.RecordError()
+				m.log.LogStreamError(runErr)
+			}
 		}
 	}()
 
@@ -131,9 +135,12 @@ func (m *streamModule) Stop(ctx context.Context) error {
 	}
 
 	m.health.SetRunning(false)
+	m.metrics.MarkStopped()
 	snap := m.metrics.Snapshot()
-	m.log.LogStreamStop(snap.Errors,
+	// Stream modules don't intercept individual messages, so messages_processed is 0.
+	m.log.LogStreamStop(0,
 		slog.Duration("uptime", snap.Uptime),
+		slog.Int64("errors", snap.Errors),
 	)
 
 	return nil

--- a/internal/stream_module.go
+++ b/internal/stream_module.go
@@ -21,21 +21,25 @@ const (
 
 // streamModule wraps a complete Bento stream (input → pipeline → output) as a ModuleInstance.
 type streamModule struct {
-	name   string
-	config map[string]any
-	stream *service.Stream
-	cancel context.CancelFunc
-	done   chan struct{}
-	status streamStatus
-	mu     sync.RWMutex
+	name    string
+	config  map[string]any
+	stream  *service.Stream
+	cancel  context.CancelFunc
+	done    chan struct{}
+	log     *bentoLogger
+	metrics *StreamMetrics
+	health  *healthTracker
 }
 
 func newStreamModule(name string, config map[string]any) (*streamModule, error) {
+	metrics := newStreamMetrics()
 	return &streamModule{
-		name:   name,
-		config: config,
-		done:   make(chan struct{}),
-		status: streamStopped,
+		name:    name,
+		config:  config,
+		done:    make(chan struct{}),
+		log:     newLogger("bento.stream", name),
+		metrics: metrics,
+		health:  newHealthTracker(metrics),
 	}, nil
 }
 
@@ -87,16 +91,17 @@ func (m *streamModule) Start(ctx context.Context) error {
 	runCtx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
-	m.setStatus(streamRunning)
-	slog.Info("bento stream running", "module", m.name)
+	m.health.SetRunning(true)
+
+	m.log.LogStreamStart("bento",
+		slog.Int("config_keys", len(m.config)),
+	)
 
 	go func() {
 		defer close(m.done)
-		if err := stream.Run(runCtx); err != nil && runCtx.Err() == nil {
-			m.setStatus(streamErrored)
-			slog.Error("bento stream failed", "error", err, "module", m.name)
-		} else {
-			m.setStatus(streamStopped)
+		if runErr := stream.Run(runCtx); runErr != nil && runCtx.Err() == nil {
+			m.metrics.RecordError()
+			m.log.LogStreamError(runErr)
 		}
 	}()
 
@@ -109,8 +114,8 @@ func (m *streamModule) Stop(ctx context.Context) error {
 
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
-			m.setStatus(streamErrored)
-			slog.Error("error stopping bento stream", "error", err, "module", m.name)
+			m.metrics.RecordError()
+			m.log.LogStreamError(err, slog.String("phase", "stop"))
 			return fmt.Errorf("bento.stream %q: stop: %w", m.name, err)
 		}
 	}
@@ -124,5 +129,18 @@ func (m *streamModule) Stop(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
+	m.health.SetRunning(false)
+	snap := m.metrics.Snapshot()
+	m.log.LogStreamStop(snap.MessagesIn,
+		slog.Duration("uptime", snap.Uptime),
+		slog.Int64("errors", snap.Errors),
+	)
+
 	return nil
+}
+
+// Health returns the current health report for this stream.
+func (m *streamModule) Health() HealthReport {
+	return m.health.Report()
 }

--- a/internal/stream_module.go
+++ b/internal/stream_module.go
@@ -4,19 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/warpstreamlabs/bento/v4/public/service"
-)
-
-// streamStatus represents the current state of a stream.
-type streamStatus string
-
-const (
-	streamStarting streamStatus = "starting"
-	streamRunning  streamStatus = "running"
-	streamStopped  streamStatus = "stopped"
-	streamErrored  streamStatus = "errored"
 )
 
 // streamModule wraps a complete Bento stream (input → pipeline → output) as a ModuleInstance.
@@ -43,19 +32,6 @@ func newStreamModule(name string, config map[string]any) (*streamModule, error) 
 	}, nil
 }
 
-// Status returns the current stream status.
-func (m *streamModule) Status() streamStatus {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.status
-}
-
-func (m *streamModule) setStatus(status streamStatus) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.status = status
-}
-
 // Init validates the configuration.
 func (m *streamModule) Init() error {
 	if len(m.config) == 0 {
@@ -66,24 +42,18 @@ func (m *streamModule) Init() error {
 
 // Start builds and runs the Bento stream.
 func (m *streamModule) Start(ctx context.Context) error {
-	m.setStatus(streamStarting)
-	slog.Info("starting bento stream", "module", m.name)
-
 	yamlStr, err := configToYAML(m.config)
 	if err != nil {
-		m.setStatus(streamErrored)
 		return fmt.Errorf("bento.stream %q: %w", m.name, err)
 	}
 
 	builder := service.NewStreamBuilder()
 	if err := builder.SetYAML(yamlStr); err != nil {
-		m.setStatus(streamErrored)
 		return fmt.Errorf("bento.stream %q: set yaml: %w", m.name, err)
 	}
 
 	stream, err := builder.Build()
 	if err != nil {
-		m.setStatus(streamErrored)
 		return fmt.Errorf("bento.stream %q: build stream: %w", m.name, err)
 	}
 	m.stream = stream
@@ -91,15 +61,14 @@ func (m *streamModule) Start(ctx context.Context) error {
 	runCtx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
-	m.health.SetRunning(true)
 	m.metrics.MarkStarted()
-
 	m.log.LogStreamStart("bento",
 		slog.Int("config_keys", len(m.config)),
 	)
 
 	go func() {
 		defer close(m.done)
+		m.health.SetRunning(true)
 		if runErr := stream.Run(runCtx); runCtx.Err() == nil {
 			m.health.SetRunning(false)
 			if runErr != nil {
@@ -114,8 +83,6 @@ func (m *streamModule) Start(ctx context.Context) error {
 
 // Stop halts the running stream and waits for the goroutine to exit.
 func (m *streamModule) Stop(ctx context.Context) error {
-	slog.Info("stopping bento stream", "module", m.name)
-
 	if m.stream != nil {
 		if err := m.stream.Stop(ctx); err != nil {
 			m.metrics.RecordError()
@@ -128,8 +95,6 @@ func (m *streamModule) Stop(ctx context.Context) error {
 	}
 	select {
 	case <-m.done:
-		m.setStatus(streamStopped)
-		slog.Info("bento stream stopped", "module", m.name)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/internal/stream_module_test.go
+++ b/internal/stream_module_test.go
@@ -152,6 +152,58 @@ func TestStreamModule_StartStop(t *testing.T) {
 	})
 }
 
+func TestStreamModule_Health(t *testing.T) {
+	m, _ := newStreamModule("test-stream", map[string]any{
+		"input": map[string]any{
+			"generate": map[string]any{
+				"mapping":  `root = {"test": "data"}`,
+				"count":    0,
+				"interval": "1s",
+			},
+		},
+		"output": map[string]any{
+			"drop": map[string]any{},
+		},
+	})
+
+	// Before start: unhealthy
+	report := m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy before start, got %s", report.StatusText)
+	}
+
+	if err := m.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Allow the stream goroutine to call Run before checking health / stopping.
+	time.Sleep(50 * time.Millisecond)
+
+	// After start: healthy
+	report = m.Health()
+	if report.Status != HealthStatusHealthy {
+		t.Errorf("expected healthy after start, got %s", report.StatusText)
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// After stop: unhealthy
+	report = m.Health()
+	if report.Status != HealthStatusUnhealthy {
+		t.Errorf("expected unhealthy after stop, got %s", report.StatusText)
+	}
+}
+
 func TestStreamModule_StopWithoutStart(t *testing.T) {
 	m, _ := newStreamModule("test", map[string]any{"input": map[string]any{}})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/stream_module_test.go
+++ b/internal/stream_module_test.go
@@ -113,8 +113,17 @@ func TestStreamModule_StartStop(t *testing.T) {
 			t.Fatalf("Start() error = %v", err)
 		}
 
-		// Let it run briefly
-		time.Sleep(50 * time.Millisecond)
+		// Wait until the stream is running before stopping.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			if m.Health().Status == HealthStatusHealthy {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("stream did not become healthy within timeout")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 
 		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()

--- a/internal/stream_module_test.go
+++ b/internal/stream_module_test.go
@@ -181,8 +181,18 @@ func TestStreamModule_Health(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 
-	// Allow the stream goroutine to call Run before checking health / stopping.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the stream goroutine to report healthy before checking health / stopping.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		report = m.Health()
+		if report.Status == HealthStatusHealthy {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected healthy after start within timeout, got %s", report.StatusText)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// After start: healthy
 	report = m.Health()
@@ -218,131 +228,4 @@ func TestStreamModule_StopWithoutStart(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Stop() without Start: expected DeadlineExceeded, got %v", err)
 	}
-}
-
-func TestStreamModule_StatusTransitions(t *testing.T) {
-	t.Run("initial status is stopped", func(t *testing.T) {
-		m, err := newStreamModule("test-stream", map[string]any{
-			"input":  map[string]any{"generate": map[string]any{}},
-			"output": map[string]any{"drop": map[string]any{}},
-		})
-		if err != nil {
-			t.Fatalf("newStreamModule() error = %v", err)
-		}
-		if got := m.Status(); got != streamStopped {
-			t.Errorf("initial status = %q, want %q", got, streamStopped)
-		}
-	})
-
-	t.Run("status is running after successful start", func(t *testing.T) {
-		m, err := newStreamModule("test-stream", map[string]any{
-			"input": map[string]any{
-				"generate": map[string]any{
-					"mapping":  `root = {"test": "data"}`,
-					"count":    0,
-					"interval": "1s",
-				},
-			},
-			"output": map[string]any{
-				"drop": map[string]any{},
-			},
-		})
-		if err != nil {
-			t.Fatalf("newStreamModule() error = %v", err)
-		}
-
-		if err := m.Init(); err != nil {
-			t.Fatalf("Init() error = %v", err)
-		}
-
-		ctx := context.Background()
-		if err := m.Start(ctx); err != nil {
-			t.Fatalf("Start() error = %v", err)
-		}
-
-		if got := m.Status(); got != streamRunning {
-			t.Errorf("status after Start = %q, want %q", got, streamRunning)
-		}
-
-		// Allow goroutine to begin running before stopping.
-		time.Sleep(50 * time.Millisecond)
-
-		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		if err := m.Stop(stopCtx); err != nil {
-			t.Fatalf("Stop() error = %v", err)
-		}
-	})
-
-	t.Run("status is stopped after successful stop", func(t *testing.T) {
-		m, err := newStreamModule("test-stream", map[string]any{
-			"input": map[string]any{
-				"generate": map[string]any{
-					"mapping":  `root = {"test": "data"}`,
-					"count":    0,
-					"interval": "1s",
-				},
-			},
-			"output": map[string]any{
-				"drop": map[string]any{},
-			},
-		})
-		if err != nil {
-			t.Fatalf("newStreamModule() error = %v", err)
-		}
-
-		if err := m.Init(); err != nil {
-			t.Fatalf("Init() error = %v", err)
-		}
-
-		ctx := context.Background()
-		if err := m.Start(ctx); err != nil {
-			t.Fatalf("Start() error = %v", err)
-		}
-
-		// Allow goroutine to begin running before stopping.
-		time.Sleep(50 * time.Millisecond)
-
-		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		if err := m.Stop(stopCtx); err != nil {
-			t.Fatalf("Stop() error = %v", err)
-		}
-
-		if got := m.Status(); got != streamStopped {
-			t.Errorf("status after Stop = %q, want %q", got, streamStopped)
-		}
-	})
-
-	t.Run("status is errored after failed start", func(t *testing.T) {
-		m, err := newStreamModule("bad-stream", map[string]any{
-			"input": map[string]any{
-				"unknown_input_type": map[string]any{
-					"invalid": "config",
-				},
-			},
-			"output": map[string]any{
-				"drop": map[string]any{},
-			},
-		})
-		if err != nil {
-			t.Fatalf("newStreamModule() error = %v", err)
-		}
-
-		if err := m.Init(); err != nil {
-			t.Fatalf("Init() error = %v", err)
-		}
-
-		ctx := context.Background()
-		if err := m.Start(ctx); err == nil {
-			t.Error("Start() expected error for invalid config, got nil")
-			_ = m.Stop(context.Background())
-			return
-		}
-
-		if got := m.Status(); got != streamErrored {
-			t.Errorf("status after failed Start = %q, want %q", got, streamErrored)
-		}
-	})
 }


### PR DESCRIPTION
## Summary
- Add structured logging via `log/slog` for all module lifecycle events (stream start/stop/error, message processed, topic events, processing start/complete/error)
- Add per-stream metrics tracking (messages in, messages out, errors, uptime, last message time) using `sync/atomic` for thread safety
- Add health status reporting per stream (healthy / degraded / unhealthy) based on running state and error count
- Integrate logging, metrics, and health into `stream_module`, `input_module`, `output_module`, `broker_module`, and `processor_step`
- Fix three pre-existing lint issues: unchecked `MetaWalkMut` return, unused `mapToMessage` helper, and `nolint` annotation on future-use `ensureStream`

Closes #3

## Test plan
- [x] Unit tests for logger structured output format (7 tests)
- [x] Unit tests for metrics counting (MessagesIn, MessagesOut, Errors, Uptime, LastMessageTime, Snapshot)
- [x] Unit tests for health status transitions (healthy → degraded → unhealthy)
- [x] Tests for concurrent metric updates (50 goroutines × 100 messages, no races)
- [x] All 21 tests pass with `-race` flag
- [x] `golangci-lint run` reports 0 issues
- [x] `go build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)