### PR TITLE
Fix bento plugin: context propagation and plugin.json capabilities

### DIFF
--- a/internal/input_module.go
+++ b/internal/input_module.go
@@ -142,7 +142,7 @@ func (m *inputModule) Start(ctx context.Context) error {
 	}
 	m.stream = stream
 
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
 
 	m.metrics.MarkStarted()

--- a/internal/output_module.go
+++ b/internal/output_module.go
@@ -115,7 +115,7 @@ func (m *outputModule) Start(ctx context.Context) error {
 	}
 	m.stream = stream
 
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
 
 	// Subscribe to the host EventBus topic before starting the stream. When

--- a/internal/stream_module.go
+++ b/internal/stream_module.go
@@ -58,7 +58,7 @@ func (m *streamModule) Start(ctx context.Context) error {
 	}
 	m.stream = stream
 
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
 
 	m.metrics.MarkStarted()

--- a/internal/trigger.go
+++ b/internal/trigger.go
@@ -94,7 +94,7 @@ func (t *bentoTrigger) parseSubscriptions() error {
 func (t *bentoTrigger) Start(ctx context.Context) error {
 	slog.Info("starting bento trigger", "subscriptions", len(t.subscriptions))
 
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(ctx)
 
 	t.mu.Lock()
 	t.cancel = cancel
@@ -176,7 +176,6 @@ func (t *bentoTrigger) Start(ctx context.Context) error {
 		slog.Info("all bento trigger streams exited")
 	}()
 
-	_ = ctx
 	return nil
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -8,5 +8,16 @@
     "license": "MIT",
     "minEngineVersion": "0.1.0",
     "keywords": ["bento", "streaming", "kafka", "sqs", "pubsub"],
-    "capabilities": []
+    "capabilities": {
+        "modules": [
+            "bento.stream",
+            "bento.input",
+            "bento.output",
+            "bento.broker"
+        ],
+        "steps": [
+            "step.bento"
+        ],
+        "triggers": []
+    }
 }


### PR DESCRIPTION
## Summary

- Replace `context.Background()` with parent `ctx` in trigger, stream, input, and output modules so context cancellation and deadlines propagate correctly
- Update `plugin.json` capabilities from an empty array to a structured object listing all provided module types (`bento.stream`, `bento.input`, `bento.output`, `bento.broker`), step types (`step.bento`), and triggers

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (`ok github.com/GoCodeAlone/workflow-plugin-bento/internal`)
- [x] Context cancellation now propagates from parent context through all module lifecycle methods
- [x] `plugin.json` accurately reflects plugin capabilities for host adapter discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)