### PR TITLE
chore: sync plugin.json version to latest tag v

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "bento",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "author": "GoCodeAlone",
     "description": "Stream processing via Bento — 100+ connectors, Bloblang transforms, at-least-once delivery",
     "type": "external",


### PR DESCRIPTION
Sync the `version` field in `plugin.json` to match the latest git release tag, eliminating drift between the published tag and the manifest the registry/consumers read.

**Change:** `version` field updated to match latest tag.

This is a pure metadata sync — no code changes.