### PR TITLE
ci: fix notify-registry draft-state release lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,13 @@ jobs:
           script: |
             const tag = process.env.GITHUB_REF_NAME;
             const { owner, repo } = context.repo;
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
+            // creates releases as draft; this step flips them to non-draft post-publish.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const release = releases.find(r => r.tag_name === tag);
+            if (!release) {
+              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
+            }
             if (release.draft) {
               await github.rest.repos.updateRelease({
                 owner,


### PR DESCRIPTION
## Summary

Fixes recurring notify-registry failure across plugin release workflows: `Publish GitHub release` step uses `github.rest.repos.getReleaseByTag` which returns 404 for DRAFT releases. GoReleaser config creates releases as draft → step fails on every release.

## Root cause

`getReleaseByTag` only returns published (non-draft) releases. Drafts have no tag indexing — accessible only by release ID. GoReleaser-created draft race the post-release script.

## Fix

Replace with `listReleases` (which DOES return drafts) + find by tag. Single deterministic API call; no 404-on-draft race.

## Affected workflow files (this PR)

`.github/workflows/release.yml` notify-registry job, `Publish GitHub release` step.

## Sibling PRs (same fix, ~9 repos affected)

This is one of 9 coordinated PRs fixing the identical bug pattern across plugin repos. Other repos: workflow-plugin-{gcp, azure, authz, authz-ui, bento, security, supply-chain, agent, tofu}.

## Test plan

- [x] YAML parses cleanly
- [ ] Next release tag exercises the fixed path (verify the publish step succeeds)

## Rollback

Revert commit. Defensive change; no other code paths touched.